### PR TITLE
Add Backstage demo build and AKS deployment assets

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+node_modules
+dist
+target
+.cache
+tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+# Multi-stage build that assembles the Backstage demo app into a production image
+# and is tuned for AKS (non-root runtime, minimal layers).
+
+# 1) Builder: clone the Backstage demo and build it
+FROM node:18-bullseye AS builder
+ARG DEMO_REPO=https://github.com/backstage/demo.git
+ARG DEMO_REF=main
+ENV APP_DIR=/app
+
+# Install build tooling
+RUN apt-get update && apt-get install -y --no-install-recommends git python3 make g++ \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR ${APP_DIR}
+RUN git clone --depth=1 --branch ${DEMO_REF} ${DEMO_REPO} .
+
+# Install and build the Backstage app
+RUN yarn install --frozen-lockfile
+RUN yarn tsc
+RUN yarn build:backend --config app-config.yaml --config app-config.production.yaml
+
+# 2) Runtime: copy the built backend bundle and run as a non-root user
+FROM node:18-bullseye-slim
+ENV APP_DIR=/app
+ENV NODE_ENV=production
+
+# Create non-root user
+RUN useradd -r -u 10001 backstage && mkdir -p ${APP_DIR} && chown backstage:backstage ${APP_DIR}
+WORKDIR ${APP_DIR}
+
+# Copy built artifacts
+COPY --from=builder /app/packages/backend/dist ./packages/backend/dist
+COPY --from=builder /app/packages/backend/package.json ./packages/backend/package.json
+COPY --from=builder /app/yarn.lock ./yarn.lock
+COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/app-config*.yaml ./
+
+# Install only backend production dependencies
+RUN yarn workspaces focus --production @backstage/backend
+
+USER backstage
+EXPOSE 7007
+CMD ["node", "packages/backend", "--config", "app-config.yaml", "--config", "app-config.production.yaml"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,95 @@
-# backstage_app-samp
-deploy on Aks and understanding of app
+# Backstage on AKS (buildable + dockerized)
+
+This repository packages the official [Backstage demo](https://github.com/backstage/demo) into a container image and provides AKS-ready configuration for PostgreSQL, NGINX ingress, Helm, and Azure integrations.
+
+## What you get
+- **Dockerfile** that clones and builds the Backstage demo app and produces a non-root runtime image.
+- **app-config.example.yaml** and **app-config.production.yaml** tuned for AKS (PostgreSQL, Azure DevOps, TechDocs, Kubernetes plugin).
+- **Plugin-ready configs** for Azure DevOps (catalog + pipelines), Grafana dashboard links, Git repos (GitHub and Azure DevOps), Kubernetes AKS status, and TechDocs.
+- **helm/values-backstage.yaml** to deploy via the Backstage Helm chart with NGINX ingress and external PostgreSQL secrets.
+
+## Prerequisites
+- Azure CLI authenticated and authorized for AKS, ACR, and PostgreSQL.
+- Docker / BuildKit, kubectl, and Helm.
+- Optional: [Azure Workload Identity](https://azure.github.io/azure-workload-identity/docs/introduction.html) for the Kubernetes plugin.
+
+## 1) Build the Backstage container
+The Dockerfile pulls the Backstage demo repo and builds the backend bundle. Customize `DEMO_REF` to pin a tag.
+
+```bash
+# Build
+docker build -t <acr-name>.azurecr.io/backstage-demo:v1 \
+  --build-arg DEMO_REF=v1.30.0 \
+  .
+
+# Push to ACR
+az acr login --name <acr-name>
+docker push <acr-name>.azurecr.io/backstage-demo:v1
+```
+
+## 2) Prepare AKS and database
+```bash
+RESOURCE_GROUP=rg-backstage
+AKS_NAME=aks-backstage
+ACR_NAME=<acr-name>
+
+# Create cluster and attach ACR
+az aks create --resource-group $RESOURCE_GROUP --name $AKS_NAME --attach-acr $ACR_NAME --node-count 3 --enable-managed-identity
+az aks get-credentials --resource-group $RESOURCE_GROUP --name $AKS_NAME
+
+# Create PostgreSQL Flexible Server (example) and capture credentials
+PG_HOST=<postgres-host>
+PG_DB=backstage
+PG_USER=backstage
+PG_PASSWORD=<password>
+```
+
+Create the secret AKS will mount into the Backstage pods:
+```bash
+kubectl create secret generic backstage-db -n portal \
+  --from-literal=host=$PG_HOST \
+  --from-literal=database=$PG_DB \
+  --from-literal=user=$PG_USER \
+  --from-literal=password=$PG_PASSWORD
+```
+
+## 3) Deploy NGINX ingress and Backstage via Helm
+```bash
+helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+helm repo add backstage https://backstage.github.io/charts
+helm repo update
+
+helm upgrade --install ingress-nginx ingress-nginx/ingress-nginx \
+  --namespace ingress-nginx --create-namespace
+
+helm upgrade --install portal backstage/backstage \
+  --namespace portal --create-namespace \
+  -f helm/values-backstage.yaml \
+  --set image.repository=<acr-name>.azurecr.io/backstage-demo \
+  --set image.tag=v1
+```
+
+After deployment, verify:
+```bash
+kubectl get pods -n portal
+kubectl get ingress -n portal
+```
+
+## 4) Configure the Backstage app
+- Copy `app-config.example.yaml` to `app-config.yaml` for local testing (`yarn dev`) or override values in `app-config.production.yaml` through environment variables when running in AKS.
+- Set `AZURE_DEVOPS_TOKEN` if you want Azure DevOps catalog and pipeline integration.
+- Configure TechDocs Azure Blob Storage credentials via `TECHDOCS_AZURE_ACCOUNT`, `TECHDOCS_AZURE_KEY`, and optional `TECHDOCS_AZURE_CONTAINER`.
+- Provide `GITHUB_TOKEN` when importing GitHub repositories into the catalog.
+- Provide `GRAFANA_URL` and `GRAFANA_API_KEY` so catalog entities annotated with Grafana dashboards can render links.
+- For the Kubernetes plugin on AKS, prefer Azure Workload Identity and set `AZURE_SUBSCRIPTION_ID` and `AZURE_TENANT_ID`.
+
+## 5) Plugin configuration
+- **Azure DevOps pipelines & repos**: set `AZURE_DEVOPS_TOKEN`, `AZURE_DEVOPS_ORG`, and `AZURE_DEVOPS_PROJECT`. The catalog provider will ingest services from the project repos, and the proxy at `/azure-devops-api` lets the Azure DevOps plugin fetch pipeline status.
+- **Grafana dashboards**: set `GRAFANA_URL` and `GRAFANA_API_KEY`. Add `grafana/dashboardUrls` annotations to catalog entities so Backstage links dashboards per service. A proxy at `/grafana-api` is available for plugins that need API access.
+- **Git repos (GitHub + Azure DevOps)**: supply `GITHUB_TOKEN` for GitHub entities, and Backstage will use the same Azure DevOps token above for DevOps repos. Add your repos to `catalog.locations` or rely on the Azure DevOps provider.
+- **Kubernetes (AKS status)**: configure `AZURE_SUBSCRIPTION_ID` and `AZURE_TENANT_ID`; use Azure Workload Identity for the pod service account to enable read-only cluster visibility via the Kubernetes plugin.
+- **TechDocs**: set Azure Blob Storage variables and annotate catalog entities with `backstage.io/techdocs-ref` to host docs via TechDocs.
+
+## Notes
+- The container runs as non-root UID `10001` and listens on port `7007`.
+- The Docker build uses the Backstage demo repo directly to keep this repository small; fork the demo if you need custom features.

--- a/app-config.example.yaml
+++ b/app-config.example.yaml
@@ -1,0 +1,77 @@
+app:
+  title: Backstage AKS Portal
+  baseUrl: http://localhost:7007
+
+backend:
+  baseUrl: http://localhost:7007
+  listen:
+    port: 7007
+    host: 0.0.0.0
+  database:
+    client: pg
+    connection:
+      host: ${PG_HOST:-localhost}
+      port: ${PG_PORT:-5432}
+      user: ${PG_USER:-postgres}
+      password: ${PG_PASSWORD:-postgres}
+      database: ${PG_DB:-backstage}
+  cors:
+    origin: "*"
+
+integrations:
+  github:
+    - host: github.com
+      token: ${GITHUB_TOKEN:-}
+  azure:
+    - host: dev.azure.com
+      token: ${AZURE_DEVOPS_TOKEN:-}
+  grafana:
+    - name: grafana
+      url: ${GRAFANA_URL:-http://grafana.local}
+      apiKey: ${GRAFANA_API_KEY:-}
+
+proxy:
+  "/azure-devops-api":
+    target: https://dev.azure.com/
+    changeOrigin: true
+    secure: true
+  "/grafana-api":
+    target: ${GRAFANA_URL:-http://grafana.local}
+    changeOrigin: true
+    secure: true
+
+techdocs:
+  builder: local
+  generator:
+    runIn: docker
+  publisher:
+    type: local
+
+catalog:
+  providers:
+    azureDevOps:
+      host: dev.azure.com
+      organization: ${AZURE_DEVOPS_ORG:-example-org}
+      project: ${AZURE_DEVOPS_PROJECT:-example-project}
+      schedule:
+        frequency: { minutes: 30 }
+        timeout: { minutes: 5 }
+  locations:
+    - type: url
+      target: https://github.com/backstage/backstage/blob/master/packages/catalog-model/examples/all.yaml
+    - type: azure/api
+      target: https://dev.azure.com/${AZURE_DEVOPS_ORG:-example-org}/${AZURE_DEVOPS_PROJECT:-example-project}/_apis/git/repositories
+      rules:
+        - allow: [Component, API, System, Domain]
+
+kubernetes:
+  serviceLocatorMethod: multiTenant
+  clusterLocatorMethods:
+    - type: config
+      clusters:
+        - name: aks
+          url: https://kubernetes.default.svc
+          authProvider: serviceAccount
+          skipTLSVerify: true
+          serviceAccountToken: ${K8S_SERVICE_ACCOUNT_TOKEN:-}
+          caData: ${K8S_CA_DATA:-}

--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -1,0 +1,68 @@
+app:
+  baseUrl: https://${PORTAL_HOSTNAME}
+
+backend:
+  baseUrl: https://${PORTAL_HOSTNAME}
+  listen:
+    port: 7007
+    host: 0.0.0.0
+  database:
+    client: pg
+    connection:
+      host: ${PG_HOST}
+      port: ${PG_PORT}
+      user: ${PG_USER}
+      password: ${PG_PASSWORD}
+      database: ${PG_DB}
+      ssl: { rejectUnauthorized: false }
+  cors:
+    origin: "https://${PORTAL_HOSTNAME}"
+
+integrations:
+  github:
+    - host: github.com
+      token: ${GITHUB_TOKEN}
+  azure:
+    - host: dev.azure.com
+      token: ${AZURE_DEVOPS_TOKEN}
+  grafana:
+    - name: grafana
+      url: ${GRAFANA_URL}
+      apiKey: ${GRAFANA_API_KEY}
+
+techdocs:
+  builder: "local"
+  generator:
+    runIn: "docker"
+  publisher:
+    type: "azureBlobStorage"
+    azureBlobStorage:
+      containerName: ${TECHDOCS_AZURE_CONTAINER:-techdocs}
+      credentials:
+        accountName: ${TECHDOCS_AZURE_ACCOUNT}
+        accountKey: ${TECHDOCS_AZURE_KEY}
+
+catalog:
+  providers:
+    azureDevOps:
+      host: dev.azure.com
+      organization: ${AZURE_DEVOPS_ORG}
+      project: ${AZURE_DEVOPS_PROJECT}
+      schedule:
+        frequency: { minutes: 30 }
+        timeout: { minutes: 5 }
+  locations:
+    - type: url
+      target: ${CATALOG_LOCATION_1:-https://github.com/backstage/backstage/blob/master/packages/catalog-model/examples/all.yaml}
+    - type: azure/api
+      target: https://dev.azure.com/${AZURE_DEVOPS_ORG}/${AZURE_DEVOPS_PROJECT}/_apis/git/repositories
+      rules:
+        - allow: [Component, API, System, Domain]
+
+kubernetes:
+  serviceLocatorMethod: multiTenant
+  clusterLocatorMethods:
+    - type: azure
+      authProvider: azureWorkloadIdentity
+      subscriptionId: ${AZURE_SUBSCRIPTION_ID}
+      tenantId: ${AZURE_TENANT_ID}

--- a/helm/values-backstage.yaml
+++ b/helm/values-backstage.yaml
@@ -1,0 +1,54 @@
+image:
+  repository: <acr-name>.azurecr.io/backstage-demo
+  tag: v1
+  pullPolicy: IfNotPresent
+  pullSecrets:
+    - name: acr-pull
+
+service:
+  type: ClusterIP
+  port: 7007
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  hosts:
+    - host: portal.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - hosts:
+        - portal.example.com
+      secretName: portal-tls
+
+extraEnvVars:
+  - name: PG_HOST
+    valueFrom:
+      secretKeyRef:
+        name: backstage-db
+        key: host
+  - name: PG_USER
+    valueFrom:
+      secretKeyRef:
+        name: backstage-db
+        key: user
+  - name: PG_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: backstage-db
+        key: password
+  - name: PG_DB
+    valueFrom:
+      secretKeyRef:
+        name: backstage-db
+        key: database
+  - name: PG_PORT
+    value: "5432"
+  - name: PORTAL_HOSTNAME
+    value: portal.example.com
+
+postgresql:
+  enabled: false


### PR DESCRIPTION
## Summary
- add Dockerfile to build and run the Backstage demo app in a non-root production image
- provide AKS-ready app configuration samples covering PostgreSQL, Azure DevOps, TechDocs, Kubernetes plugin, Grafana dashboards, and Git repo ingestion
- supply Helm values and documentation for deploying the container via ingress-nginx on AKS

## Testing
- not run (configuration and build assets only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ec0570ee08330a0b5ad28cf5ba2ea)